### PR TITLE
Improve argument parsing in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,14 +103,22 @@ install() {
 while [[ $# -gt 0 ]]; do
   case "${1}" in
     -d|--dest)
+      if [[ "$#" -eq 1 ]]; then
+        echo "ERROR: The --dest option requires an argument"
+        exit 1
+      fi
       dest="${2}"
+      shift
       if [[ ! -d "${dest}" ]]; then
         echo "ERROR: Destination directory does not exist."
         exit 1
       fi
-      shift
       ;;
     -n|--name)
+      if [[ "$#" -eq 1 ]]; then
+        echo "ERROR: The --name option requires an argument"
+        exit 1
+      fi
       name="${2}"
       shift
       ;;

--- a/install.sh
+++ b/install.sh
@@ -108,11 +108,11 @@ while [[ $# -gt 0 ]]; do
         echo "ERROR: Destination directory does not exist."
         exit 1
       fi
-      shift 2
+      shift
       ;;
     -n|--name)
       name="${2}"
-      shift 2
+      shift
       ;;
     -a|--all)
       all="true"


### PR DESCRIPTION
1. The `--dest` and `--name` options removed two arguments using `shift 2`, but then after `case-esac` there's another `shift`. This caused the `--dest` and `--name` options to consume 3 command-line arguments, instead of 2, leading to broken argument parsing. Fixed this.

2. Added a check to test if the argument to `--dest` and `--name` actually exists.