### PR TITLE
Fix install.sh producing absolute symlinks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ install() {
     rm -rf "${THEME_DIR}"/places/scalable/user-trash{'','-full'}-dark.svg
 
     cp -r "${SRC_DIR}"/links/{actions,apps,categories,devices,emotes,emblems,mimes,places,status,preferences} "${THEME_DIR}"
-    ln -s "${THEME_DIR}"/preferences/32 "${THEME_DIR}"/preferences/22
+    ln -sr "${THEME_DIR}"/preferences/32 "${THEME_DIR}"/preferences/22
   fi
 
   if [[ ${color} == '-light' ]]; then


### PR DESCRIPTION
This commit fixes `install.sh` producing a non-relative symlink for the `preferences/22` directory.